### PR TITLE
Limit Nintendo Switch's external SD SDHCI bus clock speed.

### DIFF
--- a/arch/arm64/boot/dts/nvidia/tegra210-nintendo-switch.dts
+++ b/arch/arm64/boot/dts/nvidia/tegra210-nintendo-switch.dts
@@ -941,6 +941,7 @@
 	sdhci@700b0000 {
 		status = "okay";
 		bus-width = <4>;
+		max-frequency = <150000000>;
 
 		cd-gpios = <&gpio TEGRA_GPIO(Z, 1) GPIO_ACTIVE_LOW>;
 		power-gpios = <&gpio TEGRA_GPIO(E, 4) GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
This will fix Nintendo Switch does not load rootfs with some
"incompatible" SD cards, which supports UHS SDR104 speed.

So, this patch will solve this problem by limiting bus speed
to Switch's hardware can handle.